### PR TITLE
Fixing a typo in youtube.brs and expanding the installation instructions if using a zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ address. Open up a standard web browser and visit the following URL:
     http://<rokuPlayer-ip-address> (for example, http://192.168.1.6)
 
 [Download the source as a zip](https://bitbucket.org/jesstech/roku-youtube/get/master.zip) - 
-unfortunately the manifest file needs to be in the root of the zip, so you need to extract this zip,
-and then re-compress the first level folder as it's own zip and upload that to your roku.
+unfortunately the manifest file needs to be in the root of the archive uploaded to the Roku, 
+so you need to extract this zip, and then recompress the first level folder as its own zip and 
+upload that to your Roku.
 
 Due to limitations in the sandboxing of development Roku channels, you can only
 have one development channel installed at a time.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ address. Open up a standard web browser and visit the following URL:
 
     http://<rokuPlayer-ip-address> (for example, http://192.168.1.6)
 
-[Download the source as a zip](https://bitbucket.org/jesstech/roku-youtube/get/master.zip) and upload it to your Roku device.
+[Download the source as a zip](https://bitbucket.org/jesstech/roku-youtube/get/master.zip) - 
+unfortunately the manifest file needs to be in the root of the zip, so you need to extract this zip,
+and then re-compress the first level folder as it's own zip and upload that to your roku.
 
 Due to limitations in the sandboxing of development Roku channels, you can only
 have one development channel installed at a time.

--- a/source/youtube.brs
+++ b/source/youtube.brs
@@ -424,7 +424,7 @@ Function get_xml_author() As Dynamic
     if credits.Count()>0 then
         for each author in credits
             if author.GetAttributes()["role"] = "uploader" then return author.GetAttributes()["yt:display"]
-        end forREM 
+        end for
     end if
 End Function
 


### PR DESCRIPTION
Youtube.brs had a random REM that was causing the Roku compiler to croak on upload, and the instructions needed a little beefing up, because the zip file that's generated has the code in a directory, and the roku can't find the manifest file, unless it's in the root, sadly.
